### PR TITLE
Add a builder example to show the basics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ name = "text_viewer"
 
 [[bin]]
 name = "treeview"
+
+[[bin]]
+name = "builder_basics"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ A few rust-gnome examples. To build, just do:
 > cargo build
 ```
 
+or to enable GTK 3.10 examples as well:
+
+```Shell
+> cargo build --features gtk_3_10
+```
+
 And then run the executables. Please be sure to have installed all the required libraries before building examples (the list is available on [gtk](https://github.com/rust-gnome/gtk/).
 
 ## LICENSE

--- a/builder_basics.glade
+++ b/builder_basics.glade
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <!-- interface-requires gtk+ 3.0 -->
+  <object class="GtkWindow" id="window1">
+    <property name="title" translatable="yes">Builder Basics</property>
+    <property name="default_width">320</property>
+    <property name="default_height">240</property>
+    <child>
+      <object class="GtkButton" id="button1">
+        <property name="label" translatable="yes">Big Useless Button</property>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/src/builder_basics.rs
+++ b/src/builder_basics.rs
@@ -1,0 +1,40 @@
+//! # Builder Basics Sample
+//!
+//! This sample demonstrates how to use the builder with a simple glade file
+
+extern crate gtk;
+
+#[cfg(feature = "gtk_3_10")]
+mod example {
+    use gtk;
+    use gtk::traits::*;
+    use gtk::signal::Inhibit;
+    use gtk::widgets::Builder;
+    use gtk::Window;
+
+    pub fn main() {
+        gtk::init();
+        let builder = Builder::new_from_file("./builder_basics.glade").unwrap();
+        let window: Window = builder.get_object("window1").unwrap();
+
+        window.connect_delete_event(|_, _| {
+            gtk::main_quit();
+            Inhibit(true)
+        });
+
+        window.show_all();
+        gtk::main();
+    }
+}
+
+#[cfg(feature = "gtk_3_10")]
+fn main() {
+    example::main()
+}
+
+#[cfg(not(feature = "gtk_3_10"))]
+fn main() {
+    println!("This example only work with GTK 3.10 and later");
+    println!("Did you forget to build with `--features gtk_3_10`?");
+}
+


### PR DESCRIPTION
I was playing with the `Builder` widget but could not make it work.
I decided to write a basic example so someone could help me fix what is going on and eventually add it to the example repo.

If you run `cargo build` you should see the following error:
```rust
src/builder_basics.rs:15:5: 15:22 error: the type of this value must be known in this context
src/builder_basics.rs:15     window.show_all();
                             ^~~~~~~~~~~~~~~~~
```

The glade file is taken from a [Python GTK tutorial](https://python-gtk-3-tutorial.readthedocs.org/en/latest/builder.html).

If we make this work, I should be able to add 1 or 2 examples showing how to use the builder.
Tell me what you think. :smile: