### PR TITLE
Stop using gtk crate features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ gtk = "^0"
 cairo-rs = "^0"
 
 [features]
-gtk_3_10 = ["gtk/gtk_3_10"]
-gtk_3_14 = ["gtk/gtk_3_14", "gtk_3_10"]
+gtk_3_10 = []
+gtk_3_14 = ["gtk_3_10"]
 
 [[bin]]
 name = "basic"


### PR DESCRIPTION
The examples still need features internally to remain buildable with older libraries.